### PR TITLE
Add alpha gating scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ update:2025/05/27
 *   **模块化与可配置性**: 清晰的代码结构 (数据、模型、训练器、评估器等) 和中心化的配置 (`src/config.py`)，易于理解、修改和扩展。
 *   **标准数据处理流程**: 包含时间序列数据加载、预处理 (特征选择、缺失值、标准化)、划分 (训练/验证/测试) 和 `DataLoader` 构建。
 *   **Alpha 调度策略**: 支持多种 Alpha 动态调整策略 (如 `linear`, `exponential`) 或固定值 (`constant`)。
+*   **Alpha 门控机制**: 可选的 `GatedAlphaScheduler` 在验证损失长期无改善时自动终止学生模型训练。
 *   **多维度评估**:
     *   计算常用预测指标 (MSE, MAE)。
     *   支持通过向测试数据添加噪声来评估模型的鲁棒性。
@@ -149,7 +150,7 @@ python main.py
 *   **数据处理配置**: 批次大小 (`BATCH_SIZE`) 等。
 *   **模型配置**: 选择教师和学生模型的类型及其详细超参数。
 *   **训练配置**: 训练设备 (`DEVICE`), 最大轮数 (`EPOCHS`), 优化器类型和参数 (`LEARNING_RATE`, `WEIGHT_DECAY`), Early Stopping 设置 (`PATIENCE`), 任务损失函数 (`LOSS_FN`)。
-*   **RDT 配置**: Alpha 调度策略 (`ALPHA_SCHEDULE`), 起始/结束 Alpha 值 (`ALPHA_START`, `ALPHA_END`), 固定 Alpha 值 (`CONSTANT_ALPHA`)。
+*   **RDT 配置**: Alpha 调度策略 (`ALPHA_SCHEDULE`), 起始/结束 Alpha 值 (`ALPHA_START`, `ALPHA_END`), 固定 Alpha 值 (`CONSTANT_ALPHA`), 以及可选的 Alpha 门控参数 (`USE_ALPHA_GATING`, `GATING_THRESHOLD`, `GATING_PATIENCE`)。
 *   **评估配置**: 需要计算的指标列表 (`METRICS`), 鲁棒性测试的噪声水平列表 (`ROBUSTNESS_NOISE_LEVELS`)。
 *   **实验管理**: 随机种子 (`SEED`) 保证可复现性, 实验名称 (`EXPERIMENT_NAME`), 稳定性运行次数 (`STABILITY_RUNS`)。
 

--- a/src/config.py
+++ b/src/config.py
@@ -64,6 +64,10 @@ class Config:
         self.ALPHA_END = 0.7
         self.ALPHA_SCHEDULE = 'linear'
         self.CONSTANT_ALPHA = 0.5
+        # 门控策略
+        self.USE_ALPHA_GATING = False
+        self.GATING_THRESHOLD = 0.01
+        self.GATING_PATIENCE = 2
 
         # --- 评估配置 ---
         self.METRICS = ['mae', 'mse']

--- a/src/schedulers.py
+++ b/src/schedulers.py
@@ -81,11 +81,38 @@ class ExponentialScheduler(BaseAlphaScheduler):
         pass
 
 
+class GatedAlphaScheduler(BaseAlphaScheduler):
+    """Wrap another scheduler and trigger training abort if validation loss doesn't improve."""
+
+    def __init__(self, base_scheduler, threshold=0.01, patience=2):
+        super().__init__(base_scheduler.alpha_start, base_scheduler.alpha_end, base_scheduler.total_epochs)
+        self.base_scheduler = base_scheduler
+        self.threshold = threshold
+        self.patience = patience
+        self.bad_epochs = 0
+        self.best_loss = float('inf')
+        self.abandon_student = False
+
+    def get_alpha(self, current_epoch):
+        return self.base_scheduler.get_alpha(current_epoch)
+
+    def update(self, current_epoch, val_loss, student_preds, teacher_preds, true_labels):
+        self.base_scheduler.update(current_epoch, val_loss, student_preds, teacher_preds, true_labels)
+        if val_loss < self.best_loss - self.threshold:
+            self.best_loss = val_loss
+            self.bad_epochs = 0
+        else:
+            self.bad_epochs += 1
+            if self.bad_epochs >= self.patience:
+                self.abandon_student = True
+
+
+
 def get_alpha_scheduler(cfg):
     """根据配置获取 alpha 调度器实例"""
     schedule_type = cfg.ALPHA_SCHEDULE.lower()
     if schedule_type == 'linear':
-        return LinearScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
+        base = LinearScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
     elif schedule_type == 'exponential':
         # 指数增长通常要求 alpha > 0，如果 alpha_start=0，可能需要调整
         start_alpha = cfg.ALPHA_START if cfg.ALPHA_START > 0 else 1e-6 # 避免 log(0) 或除以 0
@@ -97,9 +124,13 @@ def get_alpha_scheduler(cfg):
              print("Warning: ExponentialScheduler end alpha <= 0, defaulting to linear.")
              return LinearScheduler(cfg.ALPHA_START, cfg.ALPHA_END, cfg.EPOCHS)
 
-        return ExponentialScheduler(start_alpha, end_alpha, cfg.EPOCHS)
+        base = ExponentialScheduler(start_alpha, end_alpha, cfg.EPOCHS)
     elif schedule_type == 'constant':
-        return ConstantScheduler(cfg.CONSTANT_ALPHA, cfg.EPOCHS)
+        base = ConstantScheduler(cfg.CONSTANT_ALPHA, cfg.EPOCHS)
     else:
         raise ValueError(f"Unsupported alpha schedule type: {schedule_type}")
+
+    if getattr(cfg, 'USE_ALPHA_GATING', False):
+        return GatedAlphaScheduler(base, threshold=cfg.GATING_THRESHOLD, patience=cfg.GATING_PATIENCE)
+    return base
 

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -125,6 +125,10 @@ class BaseTrainer:
                 logging.info("Early stopping triggered.")
                 break
 
+            if hasattr(self, 'alpha_scheduler') and getattr(self.alpha_scheduler, 'abandon_student', False):
+                logging.info("Alpha gating triggered. Abandoning student model.")
+                break
+
         total_time = time.time() - start_time
         logging.info(f"--- Training Finished for {self.model_name} ---")
         logging.info(f"Total Training Time: {total_time:.2f}s")


### PR DESCRIPTION
## Summary
- add `GatedAlphaScheduler` to stop training when validation loss stops improving
- expose gating options in `Config`
- halt training early in `BaseTrainer` when gating triggers
- document alpha gating in README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*